### PR TITLE
Fix - Cannot read property of null

### DIFF
--- a/src/Riak/Api/Http.php
+++ b/src/Riak/Api/Http.php
@@ -697,8 +697,10 @@ class Http extends Api implements ApiInterface
             case 'Basho\Riak\Command\KVObject\Keys\Fetch':
                 $data = json_decode($body);
                 $keys = [];
-                foreach ($data->keys as $key) {
-                    $keys[] = new Location($key, $this->command->getBucket());
+                if ($data && isset($data->keys)) {
+                    foreach ($data->keys as $key) {
+                        $keys[] = new Location($key, $this->command->getBucket());
+                    }
                 }
                 $response = new Command\KVObject\Keys\Response($this->success, $this->statusCode, $this->error, $keys);
                 break;


### PR DESCRIPTION
For some request a fetch was creating a "Cannot read property of null" error.
So like for all other requests it should be verified, the response body is not empty before parsing it.